### PR TITLE
feat!: redirect the user if there is an active session

### DIFF
--- a/src/Controllers/ShowCodeForm.php
+++ b/src/Controllers/ShowCodeForm.php
@@ -4,6 +4,7 @@ namespace Empuxa\TotpLogin\Controllers;
 
 use Empuxa\TotpLogin\Exceptions\MissingSessionInformation;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 
 class ShowCodeForm extends Controller
@@ -11,8 +12,12 @@ class ShowCodeForm extends Controller
     /**
      * @throws \Throwable
      */
-    public function __invoke(): View
+    public function __invoke(): RedirectResponse|View
     {
+        if (auth()->check()) {
+            return redirect()->intended(config('totp-login.redirect'));
+        }
+
         throw_unless(session(config('totp-login.columns.identifier')), MissingSessionInformation::class);
 
         return view('totp-login::code', [

--- a/src/Controllers/ShowIdentifierForm.php
+++ b/src/Controllers/ShowIdentifierForm.php
@@ -3,12 +3,17 @@
 namespace Empuxa\TotpLogin\Controllers;
 
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 
 class ShowIdentifierForm extends Controller
 {
-    public function __invoke(): View
+    public function __invoke(): RedirectResponse|View
     {
+        if (auth()->check()) {
+            return redirect()->intended(config('totp-login.redirect'));
+        }
+
         return view('totp-login::identifier');
     }
 }

--- a/tests/Feature/Controllers/ShowCodeFormTest.php
+++ b/tests/Feature/Controllers/ShowCodeFormTest.php
@@ -2,6 +2,7 @@
 
 namespace Empuxa\TotpLogin\Tests\Feature\Controllers;
 
+use Empuxa\TotpLogin\Models\User;
 use Empuxa\TotpLogin\Tests\TestbenchTestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -13,7 +14,7 @@ class ShowCodeFormTest extends TestbenchTestCase
     {
         $response = $this->get(route('totp-login.code.form'));
 
-        $response->assertStatus(500);
+        $response->assertServerError();
     }
 
     public function test_can_render_pin_screen(): void
@@ -24,6 +25,23 @@ class ShowCodeFormTest extends TestbenchTestCase
             ])
             ->get(route('totp-login.code.form'));
 
-        $response->assertStatus(200);
+        $response->assertOk();
+    }
+
+    public function test_redirects_when_already_logged_in(): void
+    {
+        $this->withoutMiddleware();
+
+        $user = User::create([
+            'name'     => 'Admin',
+            'email'    => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->get(route('totp-login.code.form'));
+
+        $response->assertRedirect();
     }
 }

--- a/tests/Feature/Controllers/ShowIdentifierFormTest.php
+++ b/tests/Feature/Controllers/ShowIdentifierFormTest.php
@@ -2,6 +2,7 @@
 
 namespace Empuxa\TotpLogin\Tests\Feature\Controllers;
 
+use Empuxa\TotpLogin\Models\User;
 use Empuxa\TotpLogin\Tests\TestbenchTestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -13,6 +14,23 @@ class ShowIdentifierFormTest extends TestbenchTestCase
     {
         $response = $this->get(route('totp-login.identifier.form'));
 
-        $response->assertStatus(200);
+        $response->assertOk();
+    }
+
+    public function test_redirects_when_already_logged_in(): void
+    {
+        $this->withoutMiddleware();
+
+        $user = User::create([
+            'name'     => 'Admin',
+            'email'    => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->get(route('totp-login.identifier.form'));
+
+        $response->assertRedirect();
     }
 }


### PR DESCRIPTION
In some cases, users clicked on `login`, viewed the login forms, and encountered an exception because they were already logged in, but the middleware failed to detect it.

This PR addresses the issue by ensuring that logged-in users are redirected to the default page specified in the config.

**Note: This is a breaking change, as it modifies the return type of the default controller methods.**