### PR TITLE
fix: reduce default box size in mail to fit smaller screens

### DIFF
--- a/resources/views/notification.blade.php
+++ b/resources/views/notification.blade.php
@@ -7,7 +7,7 @@
 
 <div style="text-align:center;width:100%;margin:50px 0">
     @foreach($code as $digit)
-        <strong style="border:1px solid blue;padding:15px;font-size:20px;border-radius:5px;margin:0 2px">{{ $digit }}</strong>
+        <strong style="border:1px solid blue;padding:10px;font-size:20px;border-radius:5px;margin:0 2px">{{ $digit }}</strong>
     @endforeach
 </div>
 


### PR DESCRIPTION
On smaller screens, the boxes float incorrectly.

This PR fixes it from
![CleanShot 2024-11-16 at 20 09 56](https://github.com/user-attachments/assets/08626a10-e5d7-4ec8-ba60-643ad04d2ad0)

to
![CleanShot 2024-11-16 at 20 09 06](https://github.com/user-attachments/assets/2940d4f9-6ca0-4ee1-aaac-51465e9ad4b9)
